### PR TITLE
Reopening "Add conforms_to/source/implements annotations" (PR #22)

### DIFF
--- a/src/schema/access_method.yaml
+++ b/src/schema/access_method.yaml
@@ -11,6 +11,8 @@ imports:
 classes:
   AccessMethod:
     description: 'Description of an access method (i.e. communication protocol) that can be used to fetch a File object (orig: DrsObject). Exact copy of the AccessMethod object of the GA4GH DRS data model (https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/AccessMethodModel)'
+    conforms_to: "GA4GH DRS 1.4.0"
+    source: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/
     slots:
       - access_method
       - access_url

--- a/src/schema/access_method.yaml
+++ b/src/schema/access_method.yaml
@@ -16,7 +16,8 @@ classes:
     conforms_to: "GA4GH DRS 1.4.0"
     class_uri: ga4gh_drs:AccessMethod
     source: ga4gh_drs_info:openapi.yaml
-    see_also: ga4gh_drs_info:docs/#tag/AccessMethodModel
+    see_also:
+      - ga4gh_drs_info:docs/#tag/AccessMethodModel
     slots:
       - access_method
       - access_url

--- a/src/schema/access_method.yaml
+++ b/src/schema/access_method.yaml
@@ -4,7 +4,7 @@ name: access_method
 prefixes:
   linkml: https://w3id.org/linkml/
   ga4gh_drs_info: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/
-  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
+#  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
 
 imports:
   - linkml:types
@@ -14,7 +14,7 @@ classes:
   AccessMethod:
     description: 'Description of an access method (i.e. communication protocol) that can be used to fetch a File object (orig: DrsObject). Exact copy of the AccessMethod object of the GA4GH DRS data model.'
     conforms_to: "GA4GH DRS 1.4.0"
-    class_uri: ga4gh_drs:AccessMethod
+#    class_uri: ga4gh_drs:AccessMethod
     source: ga4gh_drs_info:openapi.yaml
     see_also:
       - ga4gh_drs_info:docs/#tag/AccessMethodModel
@@ -47,14 +47,14 @@ enums:
 slots:
   access_method:
     description: 'Access method used to access the File object (orig: DrsObject).'
-    slot_uri: ga4gh_drs:AccessMethod/type
+#    slot_uri: ga4gh_drs:AccessMethod/type
     required: true
     range: AccessMethods
     examples:
       - value: https
   access_url: 
     description: 'AccessURL object providing URL and associated HTTP headers to access the File object (orig: DrsObject).'
-    slot_uri: ga4gh_drs:AccessMethod/access_url
+#    slot_uri: ga4gh_drs:AccessMethod/access_url
     required: true
     range: AccessURL
     examples:
@@ -62,6 +62,6 @@ slots:
           url: 'https://epigenomesportal.ca/tracks/ENCODE/hg38/87234.ENCODE.ENCBS004ENC.H3K9me3.peak_calls.bigBed'
   region:
     description: 'Name of the region in the cloud service provider that the object belongs to.'
-    slot_uri: ga4gh_drs:AccessMethod/region
+#    slot_uri: ga4gh_drs:AccessMethod/region
     range: string
     examples: []

--- a/src/schema/access_method.yaml
+++ b/src/schema/access_method.yaml
@@ -3,6 +3,8 @@ name: access_method
 
 prefixes:
   linkml: https://w3id.org/linkml/
+  ga4gh_drs_info: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/
+  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
 
 imports:
   - linkml:types
@@ -10,9 +12,11 @@ imports:
 
 classes:
   AccessMethod:
-    description: 'Description of an access method (i.e. communication protocol) that can be used to fetch a File object (orig: DrsObject). Exact copy of the AccessMethod object of the GA4GH DRS data model (https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/AccessMethodModel)'
+    description: 'Description of an access method (i.e. communication protocol) that can be used to fetch a File object (orig: DrsObject). Exact copy of the AccessMethod object of the GA4GH DRS data model.'
     conforms_to: "GA4GH DRS 1.4.0"
-    source: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/
+    class_uri: ga4gh_drs:AccessMethod
+    source: ga4gh_drs_info:openapi.yaml
+    see_also: ga4gh_drs_info:docs/#tag/AccessMethodModel
     slots:
       - access_method
       - access_url
@@ -42,12 +46,14 @@ enums:
 slots:
   access_method:
     description: 'Access method used to access the File object (orig: DrsObject).'
+    slot_uri: ga4gh_drs:AccessMethod/type
     required: true
     range: AccessMethods
     examples:
       - value: https
   access_url: 
     description: 'AccessURL object providing URL and associated HTTP headers to access the File object (orig: DrsObject).'
+    slot_uri: ga4gh_drs:AccessMethod/access_url
     required: true
     range: AccessURL
     examples:
@@ -55,5 +61,6 @@ slots:
           url: 'https://epigenomesportal.ca/tracks/ENCODE/hg38/87234.ENCODE.ENCBS004ENC.H3K9me3.peak_calls.bigBed'
   region:
     description: 'Name of the region in the cloud service provider that the object belongs to.'
+    slot_uri: ga4gh_drs:AccessMethod/region
     range: string
     examples: []

--- a/src/schema/access_url.yaml
+++ b/src/schema/access_url.yaml
@@ -15,7 +15,8 @@ classes:
     conforms_to: "GA4GH DRS 1.4.0"
     class_uri: ga4gh_drs:AccessURL
     source: ga4gh_drs_info:openapi.yaml
-    see_also: ga4gh_drs_info:docs/#tag/AccessURLModel
+    see_also:
+      - ga4gh_drs_info:docs/#tag/AccessURLModel
     slots:
       - url
       - headers

--- a/src/schema/access_url.yaml
+++ b/src/schema/access_url.yaml
@@ -4,7 +4,7 @@ name: access_url
 prefixes:
   linkml: https://w3id.org/linkml/
   ga4gh_drs_info: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/
-  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
+#  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
 
 imports:
   - linkml:types
@@ -13,7 +13,7 @@ classes:
   AccessURL:
     description: 'The URL and associated HTTP headers to access the File object (orig: DrsObject). Exact copy of AccessURL object of the GA4GH DRS data model.'
     conforms_to: "GA4GH DRS 1.4.0"
-    class_uri: ga4gh_drs:AccessURL
+#    class_uri: ga4gh_drs:AccessURL
     source: ga4gh_drs_info:openapi.yaml
     see_also:
       - ga4gh_drs_info:docs/#tag/AccessURLModel
@@ -24,14 +24,14 @@ classes:
 slots:
   url: 
     description: 'A fully resolvable URL that can be used to fetch the actual object bytes.'
-    slot_uri: ga4gh_drs:AccessURL/url
+#    slot_uri: ga4gh_drs:AccessURL/url
     required: true
     range: uri
     examples:
       - value: 'https://epigenomesportal.ca/tracks/ENCODE/hg38/87234.ENCODE.ENCBS004ENC.H3K9me3.peak_calls.bigBed'
   headers:
     description: 'An optional list of headers to include in the HTTP request to `url`. These headers can be used to provide auth tokens required to fetch the object bytes.'
-    slot_uri: ga4gh_drs:AccessURL/headers
+#    slot_uri: ga4gh_drs:AccessURL/headers
     range: string
     multivalued: true
     examples: []

--- a/src/schema/access_url.yaml
+++ b/src/schema/access_url.yaml
@@ -10,6 +10,8 @@ imports:
 classes:
   AccessURL:
     description: 'The URL and associated HTTP headers to access the File object (orig: DrsObject). Exact copy of AccessURL object of the GA4GH DRS data model (https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/AccessURLModel).'
+    conforms_to: "GA4GH DRS 1.4.0"
+    source: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/
     slots: 
       - url
       - headers

--- a/src/schema/access_url.yaml
+++ b/src/schema/access_url.yaml
@@ -3,28 +3,34 @@ name: access_url
 
 prefixes:
   linkml: https://w3id.org/linkml/
+  ga4gh_drs_info: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/
+  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
 
 imports:
   - linkml:types
 
 classes:
   AccessURL:
-    description: 'The URL and associated HTTP headers to access the File object (orig: DrsObject). Exact copy of AccessURL object of the GA4GH DRS data model (https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/AccessURLModel).'
+    description: 'The URL and associated HTTP headers to access the File object (orig: DrsObject). Exact copy of AccessURL object of the GA4GH DRS data model.'
     conforms_to: "GA4GH DRS 1.4.0"
-    source: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/
-    slots: 
+    class_uri: ga4gh_drs:AccessURL
+    source: ga4gh_drs_info:openapi.yaml
+    see_also: ga4gh_drs_info:docs/#tag/AccessURLModel
+    slots:
       - url
       - headers
 
 slots:
   url: 
     description: 'A fully resolvable URL that can be used to fetch the actual object bytes.'
+    slot_uri: ga4gh_drs:AccessURL/url
     required: true
     range: uri
     examples:
       - value: 'https://epigenomesportal.ca/tracks/ENCODE/hg38/87234.ENCODE.ENCBS004ENC.H3K9me3.peak_calls.bigBed'
   headers:
     description: 'An optional list of headers to include in the HTTP request to `url`. These headers can be used to provide auth tokens required to fetch the object bytes.'
+    slot_uri: ga4gh_drs:AccessURL/headers
     range: string
     multivalued: true
     examples: []

--- a/src/schema/checksum.yaml
+++ b/src/schema/checksum.yaml
@@ -10,6 +10,8 @@ imports:
 classes:
   Checksum:
     description: 'A checksum of a File object (orig: DrsObject). Exact copy of the Checksum object of the GA4GH DRS data model (https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/ChecksumModel).'
+    conforms_to: "GA4GH DRS 1.4.0"
+    source: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/
     slots:
       - checksum
       - checksum_type

--- a/src/schema/checksum.yaml
+++ b/src/schema/checksum.yaml
@@ -4,7 +4,7 @@ name: checksum
 prefixes:
   linkml: https://w3id.org/linkml/
   ga4gh_drs_info: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/
-  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
+#  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
 
 imports:
   - linkml:types
@@ -13,7 +13,7 @@ classes:
   Checksum:
     description: 'A checksum of a File object (orig: DrsObject). Exact copy of the Checksum object of the GA4GH DRS data model.'
     conforms_to: "GA4GH DRS 1.4.0"
-    class_uri: ga4gh_drs:Checksum
+#    class_uri: ga4gh_drs:Checksum
     source: ga4gh_drs_info:openapi.yaml
     see_also:
       - ga4gh_drs_info:docs/#tag/ChecksumModel
@@ -26,13 +26,13 @@ classes:
 slots:
   checksum:
     description: 'The hex-string encoded checksum for the data.'
-    slot_uri: ga4gh_drs:Checksum/checksum
+#    slot_uri: ga4gh_drs:Checksum/checksum
     range: string
     examples:
       - value: '535bc9628a1c5e5215226f9996e4eaca'
   checksum_type:
     description: "The digest method used to create the checksum. The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://www.iana.org/assignments/named-information/named-information.xhtml#hash-alg [IANA Named Information Hash Algorithm Registry]. Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4 [RFC6920]. GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future. Until then, if implementors do choose such an algorithm (e.g. because it's implemented by their storage provider), they SHOULD use an existing standard `type` value such as `md5`, `etag`, `crc32c`, `trunc512`, or `sha1`."
-    slot_uri: ga4gh_drs:Checksum/type
+#    slot_uri: ga4gh_drs:Checksum/type
     required: true
     range: string
     examples:

--- a/src/schema/checksum.yaml
+++ b/src/schema/checksum.yaml
@@ -15,7 +15,8 @@ classes:
     conforms_to: "GA4GH DRS 1.4.0"
     class_uri: ga4gh_drs:Checksum
     source: ga4gh_drs_info:openapi.yaml
-    see_also: ga4gh_drs_info:docs/#tag/ChecksumModel
+    see_also:
+      - ga4gh_drs_info:docs/#tag/ChecksumModel
     slots:
       - checksum
       - checksum_type

--- a/src/schema/checksum.yaml
+++ b/src/schema/checksum.yaml
@@ -3,15 +3,19 @@ name: checksum
 
 prefixes:
   linkml: https://w3id.org/linkml/
+  ga4gh_drs_info: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/
+  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
 
 imports:
   - linkml:types
 
 classes:
   Checksum:
-    description: 'A checksum of a File object (orig: DrsObject). Exact copy of the Checksum object of the GA4GH DRS data model (https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/ChecksumModel).'
+    description: 'A checksum of a File object (orig: DrsObject). Exact copy of the Checksum object of the GA4GH DRS data model.'
     conforms_to: "GA4GH DRS 1.4.0"
-    source: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/
+    class_uri: ga4gh_drs:Checksum
+    source: ga4gh_drs_info:openapi.yaml
+    see_also: ga4gh_drs_info:docs/#tag/ChecksumModel
     slots:
       - checksum
       - checksum_type
@@ -21,11 +25,13 @@ classes:
 slots:
   checksum:
     description: 'The hex-string encoded checksum for the data.'
+    slot_uri: ga4gh_drs:Checksum/checksum
     range: string
     examples:
       - value: '535bc9628a1c5e5215226f9996e4eaca'
   checksum_type:
     description: "The digest method used to create the checksum. The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://www.iana.org/assignments/named-information/named-information.xhtml#hash-alg [IANA Named Information Hash Algorithm Registry]. Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4 [RFC6920]. GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future. Until then, if implementors do choose such an algorithm (e.g. because it's implemented by their storage provider), they SHOULD use an existing standard `type` value such as `md5`, `etag`, `crc32c`, `trunc512`, or `sha1`."
+    slot_uri: ga4gh_drs:Checksum/type
     required: true
     range: string
     examples:

--- a/src/schema/file.yaml
+++ b/src/schema/file.yaml
@@ -3,6 +3,9 @@ name: file
 
 prefixes:
   linkml: https://w3id.org/linkml/
+  ga4gh_drs_info: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/
+  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
+
 
 imports:
   - linkml:types

--- a/src/schema/file.yaml
+++ b/src/schema/file.yaml
@@ -14,10 +14,12 @@ imports:
 
 classes:
   File:
-    description: 'General information about a particular data file. Most fields (marked with an asterix*) are copied from the GA4GH DRS DrsObject model (https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/DrsObjectModel), which is the top-level object returned from a DRS server in response to a successful lookup call (i.e. https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/Objects).'
+    description: 'General information about a particular data file. Most fields (marked with an asterix*) are copied from the GA4GH DRS DrsObject model, which is the top-level object returned from a DRS server in response to a successful lookup call (i.e. https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/Objects).'
     conforms_to: "GA4GH DRS 1.4.0"
-    source: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/
-    slots: 
+    class_uri: ga4gh_drs:DrsObject
+    source: ga4gh_drs_info:openapi.yaml
+    see_also: ga4gh_drs_info:docs/#tag/DrsObjectModel
+    slots:
       - file_external_id
       - file_id
       - file_name
@@ -320,6 +322,7 @@ slots:
       - value: 'encode:ENCFF323LCS'
   file_id:
     description: 'Internal identifier for the data file (unique within the metadata deposit). '
+    slot_uri: ga4gh_drs:DrsObject/id
     required: true
     identifier: true
     range: curie
@@ -327,6 +330,7 @@ slots:
       - value: 'file:ENCFF323LCS'
   file_name:
     description: 'A string that can be used to name a data file. This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282 [portable filenames].'
+    slot_uri: ga4gh_drs:DrsObject/name
     range: string
     examples:
       - value: '87234.ENCODE.ENCBS004ENC.H3K9me3.peak_calls.bigBed'
@@ -339,6 +343,7 @@ slots:
       - value: 'H3K9me3 ChIP-seq replicated peaks, GRCh38, AG04450'
   file_description:
     description: 'A human readable description of the data file.'
+    slot_uri: ga4gh_drs:DrsObject/description
     range: string
     examples:
       - value: 'H3K9me3 ChIP-seq replicated peaks on human (hg38) AG04450 (Fibroblast derived cell line).'
@@ -362,11 +367,13 @@ slots:
           technical_replicate_labels: [ "1_1", "2_1" ]
   drs_uri:
     description: 'A drs:// hostname-based URI, as defined in the DRS documentation, that tells clients how to access this object. The intent of this field is to make DRS objects self-contained, and therefore easier for clients to store and pass around. For example, if you arrive at this DRS JSON by resolving a compact identifier-based DRS URI, the self_uri presents you with a hostname and properly encoded DRS ID for use in subsequent access endpoint calls.'
+    slot_uri: ga4gh_drs:DrsObject/self_uri
     range: uri
     examples:
       - value: 'drs://drs.example.org/ENCFF323LCS'
   access_methods: 
     description: 'The list of access methods that can be used to fetch the data file. '
+    slot_uri: ga4gh_drs:DrsObject/access_methods
     required: true
     range: AccessMethod
     multivalued: true
@@ -419,6 +426,7 @@ slots:
           label: 'bigBed'
   mime_type:
     description: 'A string providing the mime-type of the data file.'
+    slot_uri: ga4gh_drs:DrsObject/mime_type
     range: string
     examples:
       - value: 'application/octet-stream'
@@ -430,28 +438,33 @@ slots:
       - value: 'replicated peaks'
   file_size:
     description: 'For blobs, the blob size in bytes. '
+    slot_uri: ga4gh_drs:DrsObject/size
     required: true
     range: integer
     examples:
       - object: 5359719
   created_time:
     description: 'Timestamp of content creation in RFC3339. (This is the creation time of the underlying content, not of the JSON object.).'
+    slot_uri: ga4gh_drs:DrsObject/created_time
     required: true
     range: datetime
     examples:
       - value: '2016-11-13T17:42:04.385801+00:00'
   updated_time:
     description: 'Timestamp of content update in RFC3339, identical to created_time in systems that do not support updates. (This is the update time of the underlying content, not of the JSON object.).'
+    slot_uri: ga4gh_drs:DrsObject/updated_time
     range: datetime
     examples:
       - value: '2016-11-13T17:42:04.385801+00:00'
   file_version:
     description: 'A string representing a version. (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.).'
+    slot_uri: ga4gh_drs:DrsObject/version
     range: string
     examples:
       - value: 'efd4e74e-7875-4d13-9630-0085bc834f18'
   checksums:
     description: 'A list of checksums of the data file. At least one checksum must be provided. For blobs, the checksum is computed over the bytes in the blob.'
+    slot_uri: ga4gh_drs:DrsObject/checksums
     required: true
     range: Checksum
     multivalued: true

--- a/src/schema/file.yaml
+++ b/src/schema/file.yaml
@@ -4,7 +4,7 @@ name: file
 prefixes:
   linkml: https://w3id.org/linkml/
   ga4gh_drs_info: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/
-  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
+#  ga4gh_drs:  https://w3id.org/ga4gh/schema/drs/1.4.0/
 
 
 imports:
@@ -19,7 +19,7 @@ classes:
   File:
     description: 'General information about a particular data file. Most fields (marked with an asterix*) are copied from the GA4GH DRS DrsObject model, which is the top-level object returned from a DRS server in response to a successful lookup call (i.e. https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/Objects).'
     conforms_to: "GA4GH DRS 1.4.0"
-    class_uri: ga4gh_drs:DrsObject
+#    class_uri: ga4gh_drs:DrsObject
     source: ga4gh_drs_info:openapi.yaml
     see_also:
       - ga4gh_drs_info:docs/#tag/DrsObjectModel
@@ -326,7 +326,7 @@ slots:
       - value: 'encode:ENCFF323LCS'
   file_id:
     description: 'Internal identifier for the data file (unique within the metadata deposit). '
-    slot_uri: ga4gh_drs:DrsObject/id
+#    slot_uri: ga4gh_drs:DrsObject/id
     required: true
     identifier: true
     range: curie
@@ -334,7 +334,7 @@ slots:
       - value: 'file:ENCFF323LCS'
   file_name:
     description: 'A string that can be used to name a data file. This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282 [portable filenames].'
-    slot_uri: ga4gh_drs:DrsObject/name
+#    slot_uri: ga4gh_drs:DrsObject/name
     range: string
     examples:
       - value: '87234.ENCODE.ENCBS004ENC.H3K9me3.peak_calls.bigBed'
@@ -347,7 +347,7 @@ slots:
       - value: 'H3K9me3 ChIP-seq replicated peaks, GRCh38, AG04450'
   file_description:
     description: 'A human readable description of the data file.'
-    slot_uri: ga4gh_drs:DrsObject/description
+#    slot_uri: ga4gh_drs:DrsObject/description
     range: string
     examples:
       - value: 'H3K9me3 ChIP-seq replicated peaks on human (hg38) AG04450 (Fibroblast derived cell line).'
@@ -371,13 +371,13 @@ slots:
           technical_replicate_labels: [ "1_1", "2_1" ]
   drs_uri:
     description: 'A drs:// hostname-based URI, as defined in the DRS documentation, that tells clients how to access this object. The intent of this field is to make DRS objects self-contained, and therefore easier for clients to store and pass around. For example, if you arrive at this DRS JSON by resolving a compact identifier-based DRS URI, the self_uri presents you with a hostname and properly encoded DRS ID for use in subsequent access endpoint calls.'
-    slot_uri: ga4gh_drs:DrsObject/self_uri
+#    slot_uri: ga4gh_drs:DrsObject/self_uri
     range: uri
     examples:
       - value: 'drs://drs.example.org/ENCFF323LCS'
   access_methods: 
     description: 'The list of access methods that can be used to fetch the data file. '
-    slot_uri: ga4gh_drs:DrsObject/access_methods
+#    slot_uri: ga4gh_drs:DrsObject/access_methods
     required: true
     range: AccessMethod
     multivalued: true
@@ -430,7 +430,7 @@ slots:
           label: 'bigBed'
   mime_type:
     description: 'A string providing the mime-type of the data file.'
-    slot_uri: ga4gh_drs:DrsObject/mime_type
+#    slot_uri: ga4gh_drs:DrsObject/mime_type
     range: string
     examples:
       - value: 'application/octet-stream'
@@ -442,33 +442,33 @@ slots:
       - value: 'replicated peaks'
   file_size:
     description: 'For blobs, the blob size in bytes. '
-    slot_uri: ga4gh_drs:DrsObject/size
+#    slot_uri: ga4gh_drs:DrsObject/size
     required: true
     range: integer
     examples:
       - object: 5359719
   created_time:
     description: 'Timestamp of content creation in RFC3339. (This is the creation time of the underlying content, not of the JSON object.).'
-    slot_uri: ga4gh_drs:DrsObject/created_time
+#    slot_uri: ga4gh_drs:DrsObject/created_time
     required: true
     range: datetime
     examples:
       - value: '2016-11-13T17:42:04.385801+00:00'
   updated_time:
     description: 'Timestamp of content update in RFC3339, identical to created_time in systems that do not support updates. (This is the update time of the underlying content, not of the JSON object.).'
-    slot_uri: ga4gh_drs:DrsObject/updated_time
+#    slot_uri: ga4gh_drs:DrsObject/updated_time
     range: datetime
     examples:
       - value: '2016-11-13T17:42:04.385801+00:00'
   file_version:
     description: 'A string representing a version. (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.).'
-    slot_uri: ga4gh_drs:DrsObject/version
+#    slot_uri: ga4gh_drs:DrsObject/version
     range: string
     examples:
       - value: 'efd4e74e-7875-4d13-9630-0085bc834f18'
   checksums:
     description: 'A list of checksums of the data file. At least one checksum must be provided. For blobs, the checksum is computed over the bytes in the blob.'
-    slot_uri: ga4gh_drs:DrsObject/checksums
+#    slot_uri: ga4gh_drs:DrsObject/checksums
     required: true
     range: Checksum
     multivalued: true

--- a/src/schema/file.yaml
+++ b/src/schema/file.yaml
@@ -21,7 +21,8 @@ classes:
     conforms_to: "GA4GH DRS 1.4.0"
     class_uri: ga4gh_drs:DrsObject
     source: ga4gh_drs_info:openapi.yaml
-    see_also: ga4gh_drs_info:docs/#tag/DrsObjectModel
+    see_also:
+      - ga4gh_drs_info:docs/#tag/DrsObjectModel
     slots:
       - file_external_id
       - file_id

--- a/src/schema/file.yaml
+++ b/src/schema/file.yaml
@@ -15,6 +15,8 @@ imports:
 classes:
   File:
     description: 'General information about a particular data file. Most fields (marked with an asterix*) are copied from the GA4GH DRS DrsObject model (https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/DrsObjectModel), which is the top-level object returned from a DRS server in response to a successful lookup call (i.e. https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/#tag/Objects).'
+    conforms_to: "GA4GH DRS 1.4.0"
+    source: https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.4.0/docs/
     slots: 
       - file_external_id
       - file_id

--- a/src/schema/genome_assembly.yaml
+++ b/src/schema/genome_assembly.yaml
@@ -3,6 +3,7 @@ name: genome_assembly
 
 prefixes:
   linkml: https://w3id.org/linkml/
+  ga4gh_refget_info: https://ga4gh.github.io/refget/
 
 imports:
   - linkml:types
@@ -11,9 +12,8 @@ classes:
   GenomeAssembly:
     description: 'Information about of the exact genome assembly used to generate the annotation file, defining the genomic coordinate system for the sequence features.'
     conforms_to: "GA4GH Refget Sequence Collections v1.0"
-    implements:
-      - https://ga4gh.github.io/refget/docs/schemas/seqcol_extended_v1.0.0.json
-    source: https://ga4gh.github.io/refget/
+    source: ga4gh_refget_info:schemas/seqcol_extended_v1.0.0.json
+    see_also: ga4gh_refget_info:seqcols
     slots:
       - seqcol_digest
       - seqcol_ordered_coord_system

--- a/src/schema/genome_assembly.yaml
+++ b/src/schema/genome_assembly.yaml
@@ -13,7 +13,8 @@ classes:
     description: 'Information about of the exact genome assembly used to generate the annotation file, defining the genomic coordinate system for the sequence features.'
     conforms_to: "GA4GH Refget Sequence Collections v1.0"
     source: ga4gh_refget_info:schemas/seqcol_extended_v1.0.0.json
-    see_also: ga4gh_refget_info:seqcols
+    see_also:
+      - ga4gh_refget_info:seqcols
     slots:
       - seqcol_digest
       - seqcol_ordered_coord_system

--- a/src/schema/genome_assembly.yaml
+++ b/src/schema/genome_assembly.yaml
@@ -10,6 +10,10 @@ imports:
 classes:
   GenomeAssembly:
     description: 'Information about of the exact genome assembly used to generate the annotation file, defining the genomic coordinate system for the sequence features.'
+    conforms_to: "GA4GH Refget Sequence Collections v1.0"
+    implements:
+      - https://ga4gh.github.io/refget/docs/schemas/seqcol_extended_v1.0.0.json
+    source: https://ga4gh.github.io/refget/
     slots:
       - seqcol_digest
       - seqcol_ordered_coord_system


### PR DESCRIPTION
PR #22 was closed by mistake due to branch reshuffling.

Thanks for the suggestions. I agree that the links should be there, but suggest changing the properties. Here is an overview over relevant LinkML properties provided by Gemini:

### Summary of LinkML Metadata, URI, and Mapping Fields

The following table categorizes LinkML slots based on whether they define **Identity**, **Origin**, or **Structural Behavior**.


| Field | Category | Purpose | Best Used For... |
| :--- | :--- | :--- | :--- |
| **`class_uri`** | **Identity** | The unique **global ID** for a class concept. | Telling machines "this class represents a `Checksum` globally." |
| **`slot_uri`** | **Identity** | The unique **global ID** for a specific property. | Mapping your local field (e.g., `checksum_type`) to a standard (e.g., `drs:type`). |
| **`source`** | **Provenance** | The **machine-readable** origin or authority file. | Linking to the **OpenAPI YAML** or JSON Schema file you derived from. |
| **`see_also`** | **Documentation**| A **human-readable** link for context. | Linking to **HTML documentation**, websites, or PDF specifications. |
| **`implements`** | **Conformance** | A **strict structural contract** (interface). | Declaring that your class is a 1:1 "drop-in" replacement for an external model. |
| **`is_a`** | **Structure** | **Inheritance** from a parent LinkML class. | Reusing fields and validation rules (regex, ranges) from another LinkML class. |
| **`slot_usage`** | **Structure** | **Refinement** of inherited slots. | Changing a field's name, range, or requiredness within a specific class. |
| **`exact_mappings`**| **Mapping** | Identifies an **identical** external concept. | Stating your class is a 1:1 conceptual match for an external ID (e.g., `skos:exactMatch`). |
| **`close_mappings`**| **Mapping** | Identifies a **similar** external concept. | Linking to a concept that is nearly the same but has slight logic differences. |

---

### Key Distinctions for GitHub Implementation

#### 1. Identity vs. Mapping (`class_uri` vs. `exact_mappings`)
* **`class_uri`**: Changes the "name" of the class in machine outputs (RDF/JSON-LD). Use this for your **primary** standard alignment.
* **`exact_mappings`**: Leaves your class name alone but adds a "see also this identical thing" metadata tag. Use this for **secondary** alignments.

#### 2. Documentation vs. Provenance (`see_also` vs. `source`)
* **`see_also`**: For **humans**. It should point to the webpage where a developer can read about the Checksum model.
* **`source`**: For **machines/audit**. It should point to the raw YAML/JSON file that contains the technical definition.

#### 3. Conformance vs. Semantics (`implements` vs. `slot_uri`)
* **`implements`**: A promise that your class follows the **entire** external structure. If you delete or rename fields, use `source` instead.
* **`slot_uri`**: A promise that **this specific field** means the same thing as the external field, regardless of how you named it locally.

#### 4. Validation Note
None of the **Mapping** or **Identity** fields (URIs) provide automatic data validation. To enforce rules (like `required: true` or a `pattern`), those constraints must be explicitly defined in your local LinkML file or inherited via **`is_a`**.